### PR TITLE
Deployable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,6 @@ end
 
 # bundle install --without test --without development
 group :production do
-  # uncomment to use postgres in production, or move outside a group if your app uses postgres for development and production 
-  # gem 'pg'
+  # use postgres in production, or move outside a group if your app uses postgres for development and production 
+  gem 'pg'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -11,14 +11,15 @@ gem 'sinatra-activerecord'
 gem 'puma'
 gem 'tux'
 
-# These gems are only installed when RACK_ENV is either `development` or `test`
+# These gems are only installed when run as `bundle install --without production`
 group :development, :test do
   gem 'pry'
   gem 'shotgun'
   gem 'sqlite3'
 end
 
-# These gems are only installed when RACK_ENV is `production`
+# bundle install --without test --without development
 group :production do
-  gem 'pg'
+  # uncomment to use postgres in production, or move outside a group if your app uses postgres for development and production 
+  # gem 'pg'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,14 @@ gem 'sinatra-activerecord'
 gem 'puma'
 gem 'tux'
 
+# These gems are only installed when RACK_ENV is either `development` or `test`
 group :development, :test do
   gem 'pry'
   gem 'shotgun'
   gem 'sqlite3'
+end
+
+# These gems are only installed when RACK_ENV is `production`
+group :production do
+  gem 'pg'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,7 @@ GEM
     method_source (0.8.2)
     minitest (5.8.3)
     multi_json (1.11.2)
+    pg (0.18.4)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -76,6 +77,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport
+  pg
   pry
   puma
   rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,6 @@ GEM
     method_source (0.8.2)
     minitest (5.8.3)
     multi_json (1.11.2)
-    pg (0.18.4)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -77,7 +76,6 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport
-  pg
   pry
   puma
   rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,7 @@ GEM
     method_source (0.8.2)
     minitest (5.8.3)
     multi_json (1.11.2)
+    pg (0.18.4)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -76,6 +77,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport
+  pg
   pry
   puma
   rake
@@ -85,3 +87,6 @@ DEPENDENCIES
   sinatra-contrib
   sqlite3
   tux
+
+BUNDLED WITH
+   1.12.1

--- a/Rakefile
+++ b/Rakefile
@@ -2,20 +2,6 @@ require 'rake'
 require "sinatra/activerecord/rake"
 require ::File.expand_path('../config/environment', __FILE__)
 
-Rake::Task["db:create"].clear
-Rake::Task["db:drop"].clear
-
-# NOTE: Assumes SQLite3 DB
-desc "create the database"
-task "db:create" do
-  touch 'db/db.sqlite3'
-end
-
-desc "drop the database"
-task "db:drop" do
-  rm_f 'db/db.sqlite3'
-end
-
 desc 'Retrieves the current schema version number'
 task "db:version" do
   puts "Current version: #{ActiveRecord::Migrator.current_version}"

--- a/app/actions.rb
+++ b/app/actions.rb
@@ -2,4 +2,3 @@
 get '/' do
   erb :index
 end
-

--- a/config/database.rb
+++ b/config/database.rb
@@ -1,13 +1,35 @@
 configure do
-  # Log queries to STDOUT in development
-  if Sinatra::Application.development?
-    ActiveRecord::Base.logger = Logger.new(STDOUT)
-  end
 
-  set :database, {
-    adapter: "sqlite3",
-    database: "db/db.sqlite3"
-  }
+  case Sinatra::Application.environment
+  # Development database settings
+  when :development
+    # Log queries to STDOUT in development
+    ActiveRecord::Base.logger = Logger.new(STDOUT)
+    set :database, {
+      adapter: "sqlite3",
+      database: "db/db.sqlite3"
+    }
+  # Test database settings
+  when :test
+    set :database, {
+      adapter: "sqlite3",
+      database: "db/test.sqlite3"
+    }
+  # Production database settings, tuned for heroku
+  when :production
+    db = URI.parse(ENV['DATABASE_URL'])  # standard heroku environment variable for configuring the database
+
+    set :database, {
+      :adapter => db.scheme == 'postgres' ? 'postgresql' : db.scheme,
+      :host     => db.host,
+      :username => db.user,
+      :password => db.password,
+      :database => db.path[1..-1],
+      :encoding => 'utf8'
+    }
+  else
+    raise ArgumentError("Expected RACK_ENV to be: development, test or production")
+  end
 
   # Load all models from app/models, using autoload instead of require
   # See http://www.rubyinside.com/ruby-techniques-revealed-autoload-1652.html

--- a/config/database.rb
+++ b/config/database.rb
@@ -11,16 +11,10 @@ configure :development, :test do
 end
 
 configure :production do
-  db = URI.parse(ENV['DATABASE_URL'])  # standard heroku environment variable for configuring the database
-
-  set :database, {
-    :adapter => db.scheme == 'postgres' ? 'postgresql' : db.scheme,
-    :host     => db.host,
-    :username => db.user,
-    :password => db.password,
-    :database => db.path[1..-1],
-    :encoding => 'utf8'
-  }
+  # Database connection is configured automatically based on the DATABASE_URL
+  # environment variable. This is a feature of sinatra/activerecord support.
+  #
+  # If you're deploying to Heroku this will be set automatically.
 end
 
 configure do

--- a/config/database.rb
+++ b/config/database.rb
@@ -1,42 +1,33 @@
+
+configure :development do
+  ActiveRecord::Base.logger = Logger.new(STDOUT)
+end
+
+configure :development, :test do
+  set :database, {
+    adapter: 'sqlite3',
+    database: APP_ROOT.join('db', "#{Sinatra::Application.environment}.sqlite3")
+  }
+end
+
+configure :production do
+  db = URI.parse(ENV['DATABASE_URL'])  # standard heroku environment variable for configuring the database
+
+  set :database, {
+    :adapter => db.scheme == 'postgres' ? 'postgresql' : db.scheme,
+    :host     => db.host,
+    :username => db.user,
+    :password => db.password,
+    :database => db.path[1..-1],
+    :encoding => 'utf8'
+  }
+end
+
 configure do
-
-  case Sinatra::Application.environment
-  # Development database settings
-  when :development
-    # Log queries to STDOUT in development
-    ActiveRecord::Base.logger = Logger.new(STDOUT)
-    set :database, {
-      adapter: "sqlite3",
-      database: "db/db.sqlite3"
-    }
-  # Test database settings
-  when :test
-    set :database, {
-      adapter: "sqlite3",
-      database: "db/test.sqlite3"
-    }
-  # Production database settings, tuned for heroku
-  when :production
-    # Configure from a DATABASE_URL environment variable
-    db = URI.parse(ENV['DATABASE_URL'])  # standard heroku environment variable for configuring the database
-
-    set :database, {
-      :adapter => db.scheme == 'postgres' ? 'postgresql' : db.scheme,
-      :host     => db.host,
-      :username => db.user,
-      :password => db.password,
-      :database => db.path[1..-1],
-      :encoding => 'utf8'
-    }
-  else
-    raise ArgumentError("Expected RACK_ENV to be: development, test or production")
-  end
-
   # Load all models from app/models, using autoload instead of require
   # See http://www.rubyinside.com/ruby-techniques-revealed-autoload-1652.html
   Dir[APP_ROOT.join('app', 'models', '*.rb')].each do |model_file|
     filename = File.basename(model_file).gsub('.rb', '')
     autoload ActiveSupport::Inflector.camelize(filename), model_file
   end
-
 end

--- a/config/database.rb
+++ b/config/database.rb
@@ -17,6 +17,7 @@ configure do
     }
   # Production database settings, tuned for heroku
   when :production
+    # Configure from a DATABASE_URL environment variable
     db = URI.parse(ENV['DATABASE_URL'])  # standard heroku environment variable for configuring the database
 
     set :database, {

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -9,7 +9,6 @@ require 'sinatra/activerecord'
 require 'sinatra/contrib/all' # Requires cookies, among other things
 
 
-
 ENV['RACK_ENV'] ||= 'development'
 APP_ROOT = Pathname.new(File.expand_path('../../', __FILE__))
 APP_NAME = APP_ROOT.basename.to_s
@@ -31,6 +30,10 @@ configure :development, :test do
   require 'pry'
 end
 
+# Production Sinatra Configuration
+configure :production do
+  # NOOP
+end
 
 # Set up the database and models
 require APP_ROOT.join('config', 'database')

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -8,8 +8,6 @@ require 'sinatra'
 require 'sinatra/activerecord'
 require 'sinatra/contrib/all' # Requires cookies, among other things
 
-
-ENV['RACK_ENV'] ||= 'development'
 APP_ROOT = Pathname.new(File.expand_path('../../', __FILE__))
 APP_NAME = APP_ROOT.basename.to_s
 
@@ -17,7 +15,6 @@ APP_NAME = APP_ROOT.basename.to_s
 configure do
   set :root, APP_ROOT.to_path
   set :server, :puma
-  set :environment, ENV['RACK_ENV'].to_sym
 
   enable :sessions
   set :session_secret, ENV['SESSION_KEY'] || 'lighthouselabssecret'

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -8,21 +8,29 @@ require 'sinatra'
 require 'sinatra/activerecord'
 require 'sinatra/contrib/all' # Requires cookies, among other things
 
-require 'pry'
 
+
+ENV['RACK_ENV'] ||= 'development'
 APP_ROOT = Pathname.new(File.expand_path('../../', __FILE__))
 APP_NAME = APP_ROOT.basename.to_s
 
-# Sinatra configuration
+# Global Sinatra configuration
 configure do
   set :root, APP_ROOT.to_path
   set :server, :puma
+  set :environment, ENV['RACK_ENV'].to_sym
 
   enable :sessions
   set :session_secret, ENV['SESSION_KEY'] || 'lighthouselabssecret'
 
   set :views, File.join(Sinatra::Application.root, "app", "views")
 end
+
+# Development and Test Sinatra Configuration
+configure :development, :test do
+  require 'pry'
+end
+
 
 # Set up the database and models
 require APP_ROOT.join('config', 'database')


### PR DESCRIPTION
Changes to make a Sinatra App nearly Heroku deployable (all you need is a postgresql database addon and it should deploy).
- Updated environment.rb to initialize the RACK_ENV for Sinatra. 
- Split dev/test setup from production
- Configured the database to support dev/test/production setups.

CC/CR via @vaz ?
