### PR TITLE
Add basic setup for specs

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--format documentation --color

--- a/Gemfile
+++ b/Gemfile
@@ -23,3 +23,9 @@ group :production do
   # use postgres in production, or move outside a group if your app uses postgres for development and production 
   gem 'pg'
 end
+
+group :test do
+  gem 'rspec'
+  gem 'capybara'
+  gem 'database_cleaner'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,8 @@ group :development, :test do
   gem 'pry'
   gem 'shotgun'
   gem 'sqlite3'
+  gem 'factory_girl'
+  gem 'faker'
 end
 
 # bundle install --without test --without development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,16 +14,32 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    addressable (2.4.0)
     arel (6.0.3)
     backports (3.6.7)
     bond (0.5.1)
     builder (3.2.2)
+    capybara (2.7.1)
+      addressable
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
     coderay (1.1.0)
+    database_cleaner (1.3.0)
+    diff-lcs (1.2.5)
     i18n (0.7.0)
     json (1.8.3)
     method_source (0.8.2)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
+    mini_portile2 (2.0.0)
     minitest (5.8.3)
     multi_json (1.11.2)
+    nokogiri (1.6.7.2)
+      mini_portile2 (~> 2.0.0.rc2)
     pg (0.18.4)
     pry (0.10.3)
       coderay (~> 1.1.0)
@@ -44,6 +60,19 @@ GEM
       rack (>= 1.0)
       rack-test (~> 0.6.2)
       ripl (>= 0.7.0)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+    rspec-core (3.4.4)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-mocks (3.4.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-support (3.4.1)
     shotgun (0.9.1)
       rack (>= 1.0)
     sinatra (1.4.6)
@@ -71,16 +100,21 @@ GEM
       sinatra (>= 1.2.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   activesupport
+  capybara
+  database_cleaner
   pg
   pry
   puma
   rake
+  rspec
   shotgun
   sinatra
   sinatra-activerecord

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,10 @@ GEM
     coderay (1.1.0)
     database_cleaner (1.3.0)
     diff-lcs (1.2.5)
+    factory_girl (4.7.0)
+      activesupport (>= 3.0.0)
+    faker (1.6.3)
+      i18n (~> 0.5)
     i18n (0.7.0)
     json (1.8.3)
     method_source (0.8.2)
@@ -110,6 +114,8 @@ DEPENDENCIES
   activesupport
   capybara
   database_cleaner
+  factory_girl
+  faker
   pg
   pry
   puma

--- a/spec/factories/README.md
+++ b/spec/factories/README.md
@@ -1,0 +1,32 @@
+You can add FactoryGirl factories in this directory and they'll
+be automatically available in your tests. For example:
+
+    # spec/factories/user_factory.rb
+
+    FactoryGirl.define do
+      # basic factory for class User, just fill any required attributes
+      factory :user do
+        name Faker::Name.name
+
+        # factory that inherits from :user and customizes it
+        factory :admin_user, class: User do
+          is_admin true
+        end
+      end
+    end
+
+Using it in a test:
+
+    # spec/models/user_spec.rb
+
+    describe User do
+      let(:user) { build(:user) }       # instantiate a User but don't save it
+      let(:user2) { create(:user) }     # instantiate and save a User
+      let(:user3) { create(:user, name: 'Vaz') }  # override attribute
+      # ...
+    end
+
+For more information see:
+
+- [FactoryGirl GETTING STARTED guide](http://www.rubydoc.info/gems/factory_girl/file/GETTING_STARTED.md)
+- [Faker README](https://github.com/stympy/faker)

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -1,0 +1,16 @@
+require_relative '../spec_helper'
+
+
+# Make sure your specs are tagged with type: :feature if you
+# want to use capybara methods (visit, fill_in, click_link, have_content, etc)
+
+describe 'Home page', type: :feature do
+
+  before { visit '/' }
+
+  it 'should contain the text "Home Page"' do
+    expect(page).to have_content('Home Page')
+  end
+
+end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,27 @@
+ENV['RACK_ENV'] ||= 'test'
+
+require_relative '../config/environment'
+
+require 'rspec'
+require 'capybara/rspec' # capybara will be loaded for tests tagged :feature
+require 'database_cleaner'
+
+Capybara.app = Sinatra::Application
+
+RSpec.configure do |config|
+  # All of the following just ensures the database is wiped
+  # before every single test:
+
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,10 +5,17 @@ require_relative '../config/environment'
 require 'rspec'
 require 'capybara/rspec' # capybara will be loaded for tests tagged :feature
 require 'database_cleaner'
+require 'factory_girl'
+require 'faker'
 
 Capybara.app = Sinatra::Application
 
 RSpec.configure do |config|
+  # make the factory_girl methods available in our tests and find factories
+  # in spec/factories/*.rb
+  config.include FactoryGirl::Syntax::Methods
+  config.before(:suite) { FactoryGirl.find_definitions }
+
   # All of the following just ensures the database is wiped
   # before every single test:
 


### PR DESCRIPTION
Discussed this a bit with a few teachers... this is mostly extracted from the acceptance testing optional breakout I did (which is on another branch), since the code was already there. It adds a testing setup to the skeleton consisting of RSpec, Capybara (for feature/acceptance testing), DatabaseCleaner, FactoryGirl, Faker. It mostly follows conventions similar to `rspec-rails`.

It's all stuff students have seen (other than Capybara) by this point, so I think it makes some sense to have it available. I tried to keep it lightweight and out of the way since writing tests is not really emphasized at this point, but it's got some notes to jog their memories if they do want to explore it.

I would definitely understand the argument against adding it, that if writing tests isn't emphasized in the course material in W3-4 then maybe it's too much to be adding it here. I figure this PR is a good place to discuss it.

@interlock I talked about this a bit with you, maybe you could tag who you think might want to look at this?
