### PR TITLE
Update db config to fix db:create/db:drop

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,13 @@
-require 'rake'
 require "sinatra/activerecord/rake"
-require ::File.expand_path('../config/environment', __FILE__)
 
-desc 'Retrieves the current schema version number'
-task "db:version" do
-  puts "Current version: #{ActiveRecord::Migrator.current_version}"
+namespace :db do
+  task :load_config do
+    require ::File.expand_path('../config/environment', __FILE__)
+  end
+
+  desc 'Retrieves the current schema version number'
+  task :version do
+    puts "Current version: #{ActiveRecord::Migrator.current_version}"
+  end
 end
+

--- a/config/database.rb
+++ b/config/database.rb
@@ -5,8 +5,14 @@ end
 
 configure :development, :test do
   set :database, {
-    adapter: 'sqlite3',
-    database: APP_ROOT.join('db', "#{Sinatra::Application.environment}.sqlite3")
+    'development' => {
+      'adapter' => 'sqlite3',
+      'database' => APP_ROOT.join('db', 'development.sqlite3')
+    },
+    'test' => {
+      'adapter' => 'sqlite3',
+      'database' => APP_ROOT.join('db', 'test.sqlite3')
+    }
   }
 end
 


### PR DESCRIPTION
`rake db:create` and `rake db:drop` weren't working... `sinatra-activerecord` doesn't really set things up properly for those tasks unless you set the database config using string keys, and specifying hash with environment keys, and specific configs inside that.
